### PR TITLE
Feature/GitHub testing workflows

### DIFF
--- a/.github/workflows/backstop-sanity-test.yml
+++ b/.github/workflows/backstop-sanity-test.yml
@@ -56,4 +56,5 @@ jobs:
 
       - name: 🎭 Test Playwright
         run: |
+          npx playwright install --with-deps
           npm run sanity-test-playwright

--- a/.github/workflows/backstop-smoke-test.yml
+++ b/.github/workflows/backstop-smoke-test.yml
@@ -58,4 +58,5 @@ jobs:
       - name: 🎭 Playwright Smoke
         continue-on-error: true
         run: |
+          npx playwright install --with-deps
           npm run smoke-test-playwright

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -22,7 +22,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-
       - name: Checkout
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/docker-sanity-test.yml
+++ b/.github/workflows/docker-sanity-test.yml
@@ -26,7 +26,6 @@ jobs:
       packages: write
 
     steps:
-
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -75,7 +74,6 @@ jobs:
       packages: write
 
     steps:
-
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -113,4 +111,4 @@ jobs:
 
       - name: 🎭 Playwright Sanity
         run: |
-          cd test/configs/ && docker run --rm -t --entrypoint='' --mount type=bind,source="$(pwd)",target=/src $REGISTRY/$IMAGE_NAME_LC:$TAG sh -c "chmod -R 777 /root && chmod -R 777 /opt/pw-browsers && npm i -D playwright && npx --allow-root --yes playwright@$PLAYWRIGHT_VERSION install && backstop test --config=playwright"
+          cd test/configs/ && docker run --rm -t --entrypoint='' --mount type=bind,source="$(pwd)",target=/src $REGISTRY/$IMAGE_NAME_LC:$TAG sh -c "chmod -R 777 /root && chmod -R 777 /opt/pw-browsers && npm i -D playwright && npx --allow-root --yes playwright@$PLAYWRIGHT_VERSION install --with-deps && backstop test --config=playwright"

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -26,7 +26,6 @@ jobs:
       packages: write
 
     steps:
-
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -75,7 +74,6 @@ jobs:
       packages: write
 
     steps:
-
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -113,4 +111,4 @@ jobs:
       - name: 🎭 Playwright Smoke
         continue-on-error: true
         run: |
-          cd test/configs/ && docker run --rm -t --entrypoint='' --mount type=bind,source="$(pwd)",target=/src $REGISTRY/$IMAGE_NAME_LC:$TAG sh -c "npm -g config set user root && chmod -R 777 /root && chmod -R 777 /opt/pw-browsers && npm i -D playwright && npx --allow-root --yes playwright@$PLAYWRIGHT_VERSION install && backstop test --config=backstop_features_pw"
+          cd test/configs/ && docker run --rm -t --entrypoint='' --mount type=bind,source="$(pwd)",target=/src $REGISTRY/$IMAGE_NAME_LC:$TAG sh -c "npm -g config set user root && chmod -R 777 /root && chmod -R 777 /opt/pw-browsers && npm i -D playwright && npx --allow-root --yes playwright@$PLAYWRIGHT_VERSION install --with-deps && backstop test --config=backstop_features_pw"


### PR DESCRIPTION
This fixes playwright self-installation for CI.

Playwright needs to have `npx playwright install --with-deps` on GitHub actions runners. Not entirely sure when this became mandatory, but it's obnoxious, and needs to be done.

https://playwright.dev/docs/ci-intro