### PR TITLE
Chore/downstream pr GitHub testing workflows

### DIFF
--- a/.github/workflows/backstop-integration-test.yml
+++ b/.github/workflows/backstop-integration-test.yml
@@ -31,6 +31,6 @@ jobs:
       - name: ↧ Install
         run: npm ci
 
-      - name: 🧪 Test
+      - name: "𓋏 Run `npm run integration-test`"
         run: |
           npm run integration-test

--- a/.github/workflows/backstop-integration-test.yml
+++ b/.github/workflows/backstop-integration-test.yml
@@ -23,7 +23,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
       - name: ⬢ Setup Node & Cache
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: "npm"
           cache-dependency-path: package-lock.json

--- a/.github/workflows/backstop-sanity-test.yml
+++ b/.github/workflows/backstop-sanity-test.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   sanity-puppeteer:
-    name: 🤪 Puppet Sanity
+    name: 🤪 Puppeteer
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -31,12 +31,12 @@ jobs:
       - name: ↧ Install
         run: npm ci
 
-      - name: 🧸 Test Puppeteer
+      - name: "𓋏 Run `npm run sanity-test`"
         run: |
           npm run sanity-test
 
   sanity-playwright:
-    name: 🤪 Playwright Sanity
+    name: 🤪 Playwright
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -54,7 +54,7 @@ jobs:
       - name: ↧ Install
         run: npm ci
 
-      - name: 🎭 Test Playwright
+      - name: "🎭 Run `npm run sanity-test-playwright`"
         run: |
           npx playwright install --with-deps
           npm run sanity-test-playwright

--- a/.github/workflows/backstop-sanity-test.yml
+++ b/.github/workflows/backstop-sanity-test.yml
@@ -23,7 +23,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
       - name: ⬢ Setup Node & Cache
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: "npm"
           cache-dependency-path: package-lock.json
@@ -46,7 +46,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
       - name: ⬢ Setup Node & Cache
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: "npm"
           cache-dependency-path: package-lock.json

--- a/.github/workflows/backstop-sanity-test.yml
+++ b/.github/workflows/backstop-sanity-test.yml
@@ -56,4 +56,5 @@ jobs:
 
       - name: 🎭 Test Playwright
         run: |
+          npx playwright install --with-deps
           npm run sanity-test-playwright

--- a/.github/workflows/backstop-smoke-test.yml
+++ b/.github/workflows/backstop-smoke-test.yml
@@ -58,4 +58,5 @@ jobs:
       - name: 🎭 Playwright Smoke
         continue-on-error: true
         run: |
+          npx playwright install --with-deps
           npm run smoke-test-playwright

--- a/.github/workflows/backstop-smoke-test.yml
+++ b/.github/workflows/backstop-smoke-test.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   smoke-puppeteer:
-    name: 💨 Puppet Smoke
+    name: 💨 Puppeteer
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -31,13 +31,13 @@ jobs:
       - name: ↧ Install
         run: npm ci
 
-      - name: 🧸 Puppeteer Smoke
+      - name: "𓋏 Run `npm run smoke-test`"
         continue-on-error: true
         run: |
           npm run smoke-test
 
   smoke-playwright:
-    name: 💨 Playwright Smoke
+    name: 💨 Playwright
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -55,7 +55,7 @@ jobs:
       - name: ↧ Install
         run: npm ci
 
-      - name: 🎭 Playwright Smoke
+      - name: "🎭 Run `npm run smoke-test-playwright`"
         continue-on-error: true
         run: |
           npx playwright install --with-deps

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -22,7 +22,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-
       - name: Checkout
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
@@ -44,7 +44,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: ⬢ Setup Node & Cache
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: "npm"
           cache-dependency-path: package-lock.json

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -50,19 +50,19 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: ↧ Install
-        run: npm ci
+        run: npm ci --verbose --foreground-scripts
 
       - name: 🐳 Build Docker Builder
         run: |
-          npm run init-docker-builder
+          npm run --verbose --foreground-scripts init-docker-builder
 
       - name: 🐳 Build Docker
         run: |
-          npm run build-docker
+          npm run --verbose --foreground-scripts build-docker
 
       - name: 🐳 Load Docker
         run: |
-          npm run load-docker
+          npm run --verbose --foreground-scripts load-docker
 
       - name: 🐳 Push to ghcr.io
         run: |

--- a/.github/workflows/docker-sanity-test.yml
+++ b/.github/workflows/docker-sanity-test.yml
@@ -103,7 +103,7 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: ↧ Install
-        run: npm ci
+        run: npm ci --verbose --foreground-scripts
 
       - name: Pull Image
         run: |
@@ -111,4 +111,4 @@ jobs:
 
       - name: 🎭 Playwright Sanity
         run: |
-          cd test/configs/ && docker run --rm -t --entrypoint='' --mount type=bind,source="$(pwd)",target=/src $REGISTRY/$IMAGE_NAME_LC:$TAG sh -c "chmod -R 777 /root && chmod -R 777 /opt/pw-browsers && npm i -D playwright && npx --yes playwright@$PLAYWRIGHT_VERSION install --with-deps && backstop test --config=playwright"
+          cd test/configs/ && docker run --rm -t --entrypoint='' --mount type=bind,source="$(pwd)",target=/src $REGISTRY/$IMAGE_NAME_LC:$TAG sh -c "chmod -R 777 /root && chmod -R 777 /opt/pw-browsers && npm --verbose --foreground-scripts i -D playwright && npx --verbose --foreground-scripts --yes playwright@$PLAYWRIGHT_VERSION install --with-deps && backstop test --config=playwright"

--- a/.github/workflows/docker-sanity-test.yml
+++ b/.github/workflows/docker-sanity-test.yml
@@ -111,4 +111,4 @@ jobs:
 
       - name: 🎭 Playwright Sanity
         run: |
-          cd test/configs/ && docker run --rm -t --entrypoint='' --mount type=bind,source="$(pwd)",target=/src $REGISTRY/$IMAGE_NAME_LC:$TAG sh -c "chmod -R 777 /root && chmod -R 777 /opt/pw-browsers && npm --verbose --foreground-scripts i -D playwright && npx --verbose --foreground-scripts --yes playwright@$PLAYWRIGHT_VERSION install --with-deps && backstop test --config=playwright"
+          cd test/configs/ && docker run --rm -t --entrypoint='' --mount type=bind,source="$(pwd)",target=/src $REGISTRY/$IMAGE_NAME_LC:$TAG sh -c "chmod -R 777 /root && chmod -R 777 /opt/pw-browsers && npm --verbose --foreground-scripts i -D playwright && npx --verbose --foreground-scripts --yes playwright@$PLAYWRIGHT_VERSION install && backstop test --config=playwright"

--- a/.github/workflows/docker-sanity-test.yml
+++ b/.github/workflows/docker-sanity-test.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
@@ -49,7 +49,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: ⬢ Setup Node & Cache
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: "npm"
           cache-dependency-path: package-lock.json
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
@@ -97,7 +97,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: ⬢ Setup Node & Cache
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: "npm"
           cache-dependency-path: package-lock.json
@@ -111,4 +111,4 @@ jobs:
 
       - name: 🎭 Playwright Sanity
         run: |
-          cd test/configs/ && docker run --rm -t --entrypoint='' --mount type=bind,source="$(pwd)",target=/src $REGISTRY/$IMAGE_NAME_LC:$TAG sh -c "chmod -R 777 /root && chmod -R 777 /opt/pw-browsers && npm i -D playwright && npx --allow-root --yes playwright@$PLAYWRIGHT_VERSION install --with-deps && backstop test --config=playwright"
+          cd test/configs/ && docker run --rm -t --entrypoint='' --mount type=bind,source="$(pwd)",target=/src $REGISTRY/$IMAGE_NAME_LC:$TAG sh -c "chmod -R 777 /root && chmod -R 777 /opt/pw-browsers && npm i -D playwright && npx --yes playwright@$PLAYWRIGHT_VERSION install --with-deps && backstop test --config=playwright"

--- a/.github/workflows/docker-sanity-test.yml
+++ b/.github/workflows/docker-sanity-test.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   sanity-test-puppeteer:
-    name: 🤪 Puppeteer Sanity
+    name: 🤪 Puppeteer
     runs-on: ubuntu-latest
 
     permissions:
@@ -61,12 +61,12 @@ jobs:
         run: |
           docker pull $REGISTRY/$IMAGE_NAME_LC:$TAG
 
-      - name: 🧸 Puppeteer Sanity
+      - name: "𓋏 Run `backstop test` in Docker"
         run: |
           cd test/configs/ && docker run --rm -t --mount type=bind,source="$(pwd)",target=/src $REGISTRY/$IMAGE_NAME_LC:$TAG test
 
   sanity-test-playwright:
-    name: 🤪 Playwright Sanity
+    name: 🤪 Playwright
     runs-on: ubuntu-latest
 
     permissions:
@@ -109,6 +109,6 @@ jobs:
         run: |
           docker pull $REGISTRY/$IMAGE_NAME_LC:$TAG
 
-      - name: 🎭 Playwright Sanity
+      - name: "🎭 Run `backstop test --confg=playwright` in Docker"
         run: |
           cd test/configs/ && docker run --rm -t --entrypoint='' --mount type=bind,source="$(pwd)",target=/src $REGISTRY/$IMAGE_NAME_LC:$TAG sh -c "chmod -R 777 /root && chmod -R 777 /opt/pw-browsers && npm --verbose --foreground-scripts i -D playwright && npx --verbose --foreground-scripts --yes playwright@$PLAYWRIGHT_VERSION install && backstop test --config=playwright"

--- a/.github/workflows/docker-sanity-test.yml
+++ b/.github/workflows/docker-sanity-test.yml
@@ -26,7 +26,6 @@ jobs:
       packages: write
 
     steps:
-
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -75,7 +74,6 @@ jobs:
       packages: write
 
     steps:
-
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -113,4 +111,4 @@ jobs:
 
       - name: 🎭 Playwright Sanity
         run: |
-          cd test/configs/ && docker run --rm -t --entrypoint='' --mount type=bind,source="$(pwd)",target=/src $REGISTRY/$IMAGE_NAME_LC:$TAG sh -c "chmod -R 777 /root && chmod -R 777 /opt/pw-browsers && npm i -D playwright && npx --allow-root --yes playwright@$PLAYWRIGHT_VERSION install && backstop test --config=playwright"
+          cd test/configs/ && docker run --rm -t --entrypoint='' --mount type=bind,source="$(pwd)",target=/src $REGISTRY/$IMAGE_NAME_LC:$TAG sh -c "chmod -R 777 /root && chmod -R 777 /opt/pw-browsers && npm i -D playwright && npx --allow-root --yes playwright@$PLAYWRIGHT_VERSION install --with-deps && backstop test --config=playwright"

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
@@ -48,7 +48,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: ⬢ Setup Node & Cache
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: "npm"
           cache-dependency-path: package-lock.json
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
@@ -96,7 +96,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: ⬢ Setup Node & Cache
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: "npm"
           cache-dependency-path: package-lock.json
@@ -111,4 +111,4 @@ jobs:
       - name: 🎭 Playwright Smoke
         continue-on-error: true
         run: |
-          cd test/configs/ && docker run --rm -t --entrypoint='' --mount type=bind,source="$(pwd)",target=/src $REGISTRY/$IMAGE_NAME_LC:$TAG sh -c "npm -g config set user root && chmod -R 777 /root && chmod -R 777 /opt/pw-browsers && npm i -D playwright && npx --allow-root --yes playwright@$PLAYWRIGHT_VERSION install --with-deps && backstop test --config=backstop_features_pw"
+          cd test/configs/ && docker run --rm -t --entrypoint='' --mount type=bind,source="$(pwd)",target=/src $REGISTRY/$IMAGE_NAME_LC:$TAG sh -c "npm -g config set user root && chmod -R 777 /root && chmod -R 777 /opt/pw-browsers && npm i -D playwright && npx --yes playwright@$PLAYWRIGHT_VERSION install --with-deps && backstop test --config=backstop_features_pw"

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   smoke-test-puppeteer:
-    name: 💨 Puppeteer Smoke
+    name: 💨 Puppeteer
     runs-on: ubuntu-latest
 
     permissions:
@@ -60,13 +60,13 @@ jobs:
         run: |
           docker pull $REGISTRY/$IMAGE_NAME_LC:$TAG
 
-      - name: 🧸 Puppeteer Smoke
+      - name: "𓋏 Run `backstop test --confg=backstop_features` in Docker"
         continue-on-error: true
         run: |
           cd test/configs/ && docker run --rm -t --mount type=bind,source="$(pwd)",target=/src $REGISTRY/$IMAGE_NAME_LC:$TAG test --config=backstop_features
 
   smoke-test-playwright:
-    name: 💨 Playwright Smoke
+    name: 💨 Playwright
     runs-on: ubuntu-latest
 
     permissions:
@@ -108,7 +108,7 @@ jobs:
         run: |
           docker pull $REGISTRY/$IMAGE_NAME_LC:$TAG
 
-      - name: 🎭 Playwright Smoke
+      - name: "🎭 Run `backstop test --confg=backstop_features_pw` in Docker"
         continue-on-error: true
         run: |
           cd test/configs/ && docker run --rm -t --entrypoint='' --mount type=bind,source="$(pwd)",target=/src $REGISTRY/$IMAGE_NAME_LC:$TAG sh -c "npm -g config set user root && chmod -R 777 /root && chmod -R 777 /opt/pw-browsers && npm --verbose i -D playwright && npx --verbose --foreground-scripts --yes playwright@$PLAYWRIGHT_VERSION install && backstop test --config=backstop_features_pw"

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -111,4 +111,4 @@ jobs:
       - name: 🎭 Playwright Smoke
         continue-on-error: true
         run: |
-          cd test/configs/ && docker run --rm -t --entrypoint='' --mount type=bind,source="$(pwd)",target=/src $REGISTRY/$IMAGE_NAME_LC:$TAG sh -c "npm -g config set user root && chmod -R 777 /root && chmod -R 777 /opt/pw-browsers && npm i -D playwright && npx --yes playwright@$PLAYWRIGHT_VERSION install --with-deps && backstop test --config=backstop_features_pw"
+          cd test/configs/ && docker run --rm -t --entrypoint='' --mount type=bind,source="$(pwd)",target=/src $REGISTRY/$IMAGE_NAME_LC:$TAG sh -c "npm -g config set user root && chmod -R 777 /root && chmod -R 777 /opt/pw-browsers && npm --verbose i -D playwright && npx --verbose --foreground-scripts --yes playwright@$PLAYWRIGHT_VERSION install --with-deps && backstop test --config=backstop_features_pw"

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -26,7 +26,6 @@ jobs:
       packages: write
 
     steps:
-
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -75,7 +74,6 @@ jobs:
       packages: write
 
     steps:
-
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -113,4 +111,4 @@ jobs:
       - name: 🎭 Playwright Smoke
         continue-on-error: true
         run: |
-          cd test/configs/ && docker run --rm -t --entrypoint='' --mount type=bind,source="$(pwd)",target=/src $REGISTRY/$IMAGE_NAME_LC:$TAG sh -c "npm -g config set user root && chmod -R 777 /root && chmod -R 777 /opt/pw-browsers && npm i -D playwright && npx --allow-root --yes playwright@$PLAYWRIGHT_VERSION install && backstop test --config=backstop_features_pw"
+          cd test/configs/ && docker run --rm -t --entrypoint='' --mount type=bind,source="$(pwd)",target=/src $REGISTRY/$IMAGE_NAME_LC:$TAG sh -c "npm -g config set user root && chmod -R 777 /root && chmod -R 777 /opt/pw-browsers && npm i -D playwright && npx --allow-root --yes playwright@$PLAYWRIGHT_VERSION install --with-deps && backstop test --config=backstop_features_pw"

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -111,4 +111,4 @@ jobs:
       - name: 🎭 Playwright Smoke
         continue-on-error: true
         run: |
-          cd test/configs/ && docker run --rm -t --entrypoint='' --mount type=bind,source="$(pwd)",target=/src $REGISTRY/$IMAGE_NAME_LC:$TAG sh -c "npm -g config set user root && chmod -R 777 /root && chmod -R 777 /opt/pw-browsers && npm --verbose i -D playwright && npx --verbose --foreground-scripts --yes playwright@$PLAYWRIGHT_VERSION install --with-deps && backstop test --config=backstop_features_pw"
+          cd test/configs/ && docker run --rm -t --entrypoint='' --mount type=bind,source="$(pwd)",target=/src $REGISTRY/$IMAGE_NAME_LC:$TAG sh -c "npm -g config set user root && chmod -R 777 /root && chmod -R 777 /opt/pw-browsers && npm --verbose i -D playwright && npx --verbose --foreground-scripts --yes playwright@$PLAYWRIGHT_VERSION install && backstop test --config=backstop_features_pw"

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -12,9 +12,9 @@ permissions:
 
 jobs:
   sanity-test:
-    name: 💨 Smoke Test Docker
+    name: 💨 Docker Smoke Test
     uses: ./.github/workflows/docker-smoke-test.yml
 
   smoke-test:
-    name: 🤪 Sanity Test Docker
+    name: 🤪 Docker Sanity Test
     uses: ./.github/workflows/docker-sanity-test.yml


### PR DESCRIPTION
This fixes playwright self-installation for CI.

Playwright needs to have `npx playwright install --with-deps` on GitHub actions runners. Not entirely sure when this became mandatory, but it's obnoxious, and needs to be done.

https://playwright.dev/docs/ci-intro