### PR TITLE
ci(github): adds github workflows for CI/CD (#44)

### DIFF
--- a/.github/workflows/_backstop-docker-ci.yml
+++ b/.github/workflows/_backstop-docker-ci.yml
@@ -1,0 +1,46 @@
+name: 🙈 Backstop & Docker CI
+run-name: "CI running on ${{ github.event_name == 'pull_request' && format('PR #{0}: {1}', github.event.pull_request.number, github.event.pull_request.title) || format('latest {0}', github.ref_name) }}"
+# Tests backstopjs alone, docker build, docker push to
+# ghcr.io, docker pull from ghcr.io, and backstopjs in
+# the docker docker build.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [master, develop]
+
+permissions:
+  checks: write
+  contents: write
+  pull-requests: write
+  packages: write
+
+env:
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+
+jobs:
+  backstop-sanity-test:
+    name: Sanity Test Backstop
+    uses: ./.github/workflows/backstop-sanity-test.yml
+
+  backstop-smoke-test:
+    name: Smoke Test Backstop
+    uses: ./.github/workflows/backstop-smoke-test.yml
+
+  backstop-integration-test:
+    name: Integration Test Backstop
+    uses: ./.github/workflows/backstop-integration-test.yml
+
+  build-publish-docker:
+    name: Build Docker
+    uses: ./.github/workflows/docker-build.yml
+
+  docker-sanity-test:
+    needs: build-publish-docker
+    name: Sanity Test Docker
+    uses: ./.github/workflows/docker-sanity-test.yml
+
+  docker-smoke-test:
+    needs: build-publish-docker
+    name: Smoke Test Docker
+    uses: ./.github/workflows/docker-smoke-test.yml

--- a/.github/workflows/backstop-integration-test.yml
+++ b/.github/workflows/backstop-integration-test.yml
@@ -1,0 +1,36 @@
+name: Backstop Integration Tests
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  NODE_VERSION: 20
+
+jobs:
+  integration:
+    name: 🧩 Integration
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+
+      - name: ⬢ Setup Node & Cache
+        uses: actions/setup-node@v4
+        with:
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: ↧ Install
+        run: npm ci
+
+      - name: "𓋏 Run `npm run integration-test`"
+        run: |
+          npm run integration-test

--- a/.github/workflows/backstop-sanity-test.yml
+++ b/.github/workflows/backstop-sanity-test.yml
@@ -1,0 +1,60 @@
+name: Backstop Sanity Tests
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  NODE_VERSION: 20
+
+jobs:
+  sanity-puppeteer:
+    name: 🤪 Puppeteer
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+
+      - name: ⬢ Setup Node & Cache
+        uses: actions/setup-node@v4
+        with:
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: ↧ Install
+        run: npm ci
+
+      - name: "𓋏 Run `npm run sanity-test`"
+        run: |
+          npm run sanity-test
+
+  sanity-playwright:
+    name: 🤪 Playwright
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+
+      - name: ⬢ Setup Node & Cache
+        uses: actions/setup-node@v4
+        with:
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: ↧ Install
+        run: npm ci
+
+      - name: "🎭 Run `npm run sanity-test-playwright`"
+        run: |
+          npx playwright install --with-deps
+          npm run sanity-test-playwright

--- a/.github/workflows/backstop-smoke-test.yml
+++ b/.github/workflows/backstop-smoke-test.yml
@@ -1,0 +1,62 @@
+name: Backstop Smoke Tests
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  NODE_VERSION: 20
+
+jobs:
+  smoke-puppeteer:
+    name: 💨 Puppeteer
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+
+      - name: ⬢ Setup Node & Cache
+        uses: actions/setup-node@v4
+        with:
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: ↧ Install
+        run: npm ci
+
+      - name: "𓋏 Run `npm run smoke-test`"
+        continue-on-error: true
+        run: |
+          npm run smoke-test
+
+  smoke-playwright:
+    name: 💨 Playwright
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+
+      - name: ⬢ Setup Node & Cache
+        uses: actions/setup-node@v4
+        with:
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: ↧ Install
+        run: npm ci
+
+      - name: "🎭 Run `npm run smoke-test-playwright`"
+        continue-on-error: true
+        run: |
+          npx playwright install --with-deps
+          npm run smoke-test-playwright

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,70 @@
+name: Docker Build & Push
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  checks: write
+  contents: write
+  pull-requests: write
+  packages: write
+
+env:
+  BRANCH_NAME: ${{ github.event.pull_request.head_ref || github.event.pull_request.head.ref_name || github.head_ref || github.ref_name }}
+  NODE_VERSION: 20
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    name: 🐳 Build and Push
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+
+      - name: Set Name and Tag Vars
+        env:
+          name: "${{ env.BRANCH_NAME }}"
+        run: |
+          echo "IMAGE_NAME_LC=${IMAGE_NAME,,}" >>${GITHUB_ENV}
+          echo "TAG=${name/\//-}" >> $GITHUB_ENV
+          echo "PV=$(cat package.json | jq -r '.version')" >> $GITHUB_ENV
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: ⬢ Setup Node & Cache
+        uses: actions/setup-node@v4
+        with:
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: ↧ Install
+        run: npm ci --verbose --foreground-scripts
+
+      - name: 🐳 Build Docker Builder
+        run: |
+          npm run --verbose --foreground-scripts init-docker-builder
+
+      - name: 🐳 Build & Push Docker
+        run: |
+          docker buildx build --push --platform linux/amd64,linux/arm64 -t $REGISTRY/$IMAGE_NAME_LC:$TAG --build-arg BACKSTOPJS_VERSION=$PV docker
+
+      # - name: 🐳 Load Docker
+      #   run: |
+      #     npm run --verbose --foreground-scripts load-docker
+
+      # - name: 🐳 Push to ghcr.io
+      #   run: |
+      #     docker tag backstopjs/backstopjs:$PV $REGISTRY/$IMAGE_NAME_LC:$TAG
+      #     docker push $REGISTRY/$IMAGE_NAME_LC:$TAG

--- a/.github/workflows/docker-sanity-test.yml
+++ b/.github/workflows/docker-sanity-test.yml
@@ -1,0 +1,114 @@
+name: Docker Sanity Tests
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  checks: write
+  contents: write
+  pull-requests: write
+  packages: write
+
+env:
+  BRANCH_NAME: ${{ github.event.pull_request.head_ref || github.event.pull_request.head.ref_name || github.head_ref || github.ref_name }}
+  NODE_VERSION: 20
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  sanity-test-puppeteer:
+    name: 🤪 Puppeteer
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+
+      - name: Set Name and Tag Vars
+        env:
+          name: "${{ env.BRANCH_NAME }}"
+        run: |
+          echo "IMAGE_NAME_LC=${IMAGE_NAME,,}" >>${GITHUB_ENV}
+          echo "TAG=${name/\//-}" >> $GITHUB_ENV
+          echo "PV=$(cat package.json | jq -r '.version')" >> $GITHUB_ENV
+          echo "PLAYWRIGHT_VERSION=$(cat package.json | jq -r '.dependencies.playwright')"  >> $GITHUB_ENV
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: ⬢ Setup Node & Cache
+        uses: actions/setup-node@v4
+        with:
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: ↧ Install
+        run: npm ci
+
+      - name: Pull Image
+        run: |
+          docker pull $REGISTRY/$IMAGE_NAME_LC:$TAG
+
+      - name: "𓋏 Run `backstop test` in Docker"
+        run: |
+          cd test/configs/ && docker run --rm -t --mount type=bind,source="$(pwd)",target=/src $REGISTRY/$IMAGE_NAME_LC:$TAG test
+
+  sanity-test-playwright:
+    name: 🤪 Playwright
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+
+      - name: Set Name and Tag Vars
+        env:
+          name: "${{ env.BRANCH_NAME }}"
+        run: |
+          echo "IMAGE_NAME_LC=${IMAGE_NAME,,}" >>${GITHUB_ENV}
+          echo "TAG=${name/\//-}" >> $GITHUB_ENV
+          echo "PV=$(cat package.json | jq -r '.version')" >> $GITHUB_ENV
+          echo "PLAYWRIGHT_VERSION=$(cat package.json | jq -r '.dependencies.playwright')"  >> $GITHUB_ENV
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: ⬢ Setup Node & Cache
+        uses: actions/setup-node@v4
+        with:
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: ↧ Install
+        run: npm ci --verbose --foreground-scripts
+
+      - name: Pull Image
+        run: |
+          docker pull $REGISTRY/$IMAGE_NAME_LC:$TAG
+
+      - name: "🎭 Run `backstop test --confg=playwright` in Docker"
+        run: |
+          cd test/configs/ && docker run --rm -t --entrypoint='' --mount type=bind,source="$(pwd)",target=/src $REGISTRY/$IMAGE_NAME_LC:$TAG sh -c "chmod -R 777 /root && chmod -R 777 /opt/pw-browsers && npm --verbose --foreground-scripts i -D playwright && npx --verbose --foreground-scripts --yes playwright@$PLAYWRIGHT_VERSION install && backstop test --config=playwright"

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -1,0 +1,114 @@
+name: Docker Smoke Tests
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  checks: write
+  contents: write
+  pull-requests: write
+  packages: write
+
+env:
+  BRANCH_NAME: ${{ github.event.pull_request.head_ref || github.event.pull_request.head.ref_name || github.head_ref || github.ref_name }}
+  NODE_VERSION: 20
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  smoke-test-puppeteer:
+    name: 💨 Puppeteer
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+
+      - name: Set Name and Tag Vars
+        env:
+          name: "${{ env.BRANCH_NAME }}"
+        run: |
+          echo "IMAGE_NAME_LC=${IMAGE_NAME,,}" >>${GITHUB_ENV}
+          echo "TAG=${name/\//-}" >> $GITHUB_ENV
+          echo "PV=$(cat package.json | jq -r '.version')" >> $GITHUB_ENV
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: ⬢ Setup Node & Cache
+        uses: actions/setup-node@v4
+        with:
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: ↧ Install
+        run: npm ci
+
+      - name: Pull Image
+        run: |
+          docker pull $REGISTRY/$IMAGE_NAME_LC:$TAG
+
+      - name: "𓋏 Run `backstop test --confg=backstop_features` in Docker"
+        continue-on-error: true
+        run: |
+          cd test/configs/ && docker run --rm -t --mount type=bind,source="$(pwd)",target=/src $REGISTRY/$IMAGE_NAME_LC:$TAG test --config=backstop_features
+
+  smoke-test-playwright:
+    name: 💨 Playwright
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+
+      - name: Set Name and Tag Vars
+        env:
+          name: "${{ env.BRANCH_NAME }}"
+        run: |
+          echo "IMAGE_NAME_LC=${IMAGE_NAME,,}" >>${GITHUB_ENV}
+          echo "TAG=${name/\//-}" >> $GITHUB_ENV
+          echo "PV=$(cat package.json | jq -r '.version')" >> $GITHUB_ENV
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: ⬢ Setup Node & Cache
+        uses: actions/setup-node@v4
+        with:
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: ↧ Install
+        run: npm ci
+
+      - name: Pull Image
+        run: |
+          docker pull $REGISTRY/$IMAGE_NAME_LC:$TAG
+
+      - name: "🎭 Run `backstop test --confg=backstop_features_pw` in Docker"
+        continue-on-error: true
+        run: |
+          cd test/configs/ && docker run --rm -t --entrypoint='' --mount type=bind,source="$(pwd)",target=/src $REGISTRY/$IMAGE_NAME_LC:$TAG sh -c "chmod -R 777 /root && chmod -R 777 /opt/pw-browsers && npm --verbose i -D playwright && npx --verbose --foreground-scripts --yes playwright@$PLAYWRIGHT_VERSION install && backstop test --config=backstop_features_pw"

--- a/.github/workflows/test-backstop.yml
+++ b/.github/workflows/test-backstop.yml
@@ -1,0 +1,23 @@
+name: Backstop Tests
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  checks: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  sanity-test:
+    name: 🤪 Backstop Sanity Test
+    uses: ./.github/workflows/backstop-sanity-test.yml
+
+  smoke-test:
+    name: 💨 Backstop Smoke Test
+    uses: ./.github/workflows/backstop-smoke-test.yml
+
+  integration-test:
+    name: 🧩 Backstop Integration Test
+    uses: ./.github/workflows/backstop-integration-test.yml

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -1,0 +1,20 @@
+name: Docker Tests
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  checks: write
+  contents: write
+  pull-requests: write
+  packages: write
+
+jobs:
+  sanity-test:
+    name: 💨 Docker Smoke Test
+    uses: ./.github/workflows/docker-smoke-test.yml
+
+  smoke-test:
+    name: 🤪 Docker Sanity Test
+    uses: ./.github/workflows/docker-sanity-test.yml


### PR DESCRIPTION
# GitHub Actions (#44)

In a separate branch, I created some GitHub actions and workflows. Happy to submit a PR with those changes as well. And do a walkthrough if you're curious :)

## Tests

### Backstop

- [![Backstop Tests](https://github.com/dgrebb/BackstopJS/actions/workflows/test-backstop.yml/badge.svg)](https://github.com/dgrebb/BackstopJS/actions/workflows/test-backstop.yml)
- [![Backstop Integration Tests](https://github.com/dgrebb/BackstopJS/actions/workflows/backstop-integration-test.yml/badge.svg)](https://github.com/dgrebb/BackstopJS/actions/workflows/backstop-integration-test.yml)
- [![Backstop Sanity Tests](https://github.com/dgrebb/BackstopJS/actions/workflows/backstop-sanity-test.yml/badge.svg)](https://github.com/dgrebb/BackstopJS/actions/workflows/backstop-sanity-test.yml)
- [![Backstop Smoke Tests](https://github.com/dgrebb/BackstopJS/actions/workflows/backstop-smoke-test.yml/badge.svg)](https://github.com/dgrebb/BackstopJS/actions/workflows/backstop-smoke-test.yml)

### Docker

- [![Docker Tests](https://github.com/dgrebb/BackstopJS/actions/workflows/test-docker.yml/badge.svg)](https://github.com/dgrebb/BackstopJS/actions/workflows/test-docker.yml)
- [![Docker Build & Push](https://github.com/dgrebb/BackstopJS/actions/workflows/docker-build.yml/badge.svg)](https://github.com/dgrebb/BackstopJS/actions/workflows/docker-build.yml)
- [![Docker Sanity Tests](https://github.com/dgrebb/BackstopJS/actions/workflows/docker-sanity-test.yml/badge.svg)](https://github.com/dgrebb/BackstopJS/actions/workflows/docker-sanity-test.yml)
- [![Docker Smoke Tests](https://github.com/dgrebb/BackstopJS/actions/workflows/docker-smoke-test.yml/badge.svg)](https://github.com/dgrebb/BackstopJS/actions/workflows/docker-smoke-test.yml)

~~A note on Docker and Playwright — to test an image built on GitHub, it seems one must make `npm` run as `root`, set `777` permissions on `/root` and `/opt/pw-browsers`, reinstall playwright the long way.~~

~~In the future I'll make adjustments to the `Dockerfile` so the workflow doesn't need to override `entrypoint`. You can see the full, long-form command in `.github/workflows/docker-smoke-test.yml` and `.github/workflows/docker-sanity-test.yml`.~~

The above was resolved in #1523

Various categories of tests have their own workflow, run independently, or together in a reusable workflow. Bringing them all together:

[![🙈 Backstop & Docker CI](https://github.com/dgrebb/BackstopJS/actions/workflows/_backstop-docker-ci.yml/badge.svg)](https://github.com/dgrebb/BackstopJS/actions/workflows/_backstop-docker-ci.yml)

This is a good first step towards a PR-checks workflow, which can run against any fork PRs to the upstream. For example, [here are](https://github.com/dgrebb/BackstopJS/pull/45) the PR and checks run against this feature in my fork.

#### Docker Build Artifacts

The docker build workflow initializes the builder, builds the image, tags it as the fork/branch-name (for PR testing purposes), and pushes it to GHCR.

An example of the final workflow-built and pushed container can [be seen here](https://github.com/dgrebb/BackstopJS/pkgs/container/backstopjs/159421941?tag=feature-44-github-workflows).  Any fork's workflow-created images will remain unique to their owner.

## Docker Tests

All Docker-specific workflows are currently re-installing Playwright by overriding the `entrypoint`. This had to be done while using the untouched Dockerfile to build this all out. The *new* Dockerfile in the PR for #34 includes `npx playwright install --with-deps` to avoid this moving forward.